### PR TITLE
Update overview_scene.md code snippet

### DIFF
--- a/guides/overview_scene.md
+++ b/guides/overview_scene.md
@@ -52,7 +52,7 @@ whose helper function is imported from the `Scenic.Components` module.
 
         @graph Graph.build()
           |> text("Hello World", font_size: 22, translate: {20, 80})
-          |> button({"Do Something", :btn_something}, translate: {20, 180})
+          |> button("Do Something", translate: {20, 180})
 
         def init( _scene_args, _options ) do
           {:ok, @graph, push: @graph}


### PR DESCRIPTION
In the `MyApp.Scene.Example` snippet, I replaced a tuple as the first parameter to `button` with a string.

## Description

The first parameter to `button` in the example was `{"Do Something", :btn_something}`. This would not compile, so I replaced this parameter with `"Do Something"`, which allows it to compile.

## Motivation and Context

I ran into this when reading through the docs and experimenting with the examples.

## Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [X] Check other PRs and make sure that the changes are not done yet.
- [X] The PR title is no longer than 64 characters.
